### PR TITLE
Removed reference to UserPrincipal.Current.DisplayName (Issue#7)

### DIFF
--- a/365-Project-Online-OM-ProjToolV2/ProjToolV2/Utilities/CsomHelper.cs
+++ b/365-Project-Online-OM-ProjToolV2/ProjToolV2/Utilities/CsomHelper.cs
@@ -20,8 +20,7 @@ namespace ProjToolV2
 
         public static EnterpriseResource LoadMe()
         {
-            string currentUserName = UserPrincipal.Current.DisplayName;
-            Log.WriteVerbose(new SourceInfo(), "Loading current user:[{0}] info.", currentUserName);
+            Log.WriteVerbose(new SourceInfo(), "Loading current user info.");
             User user = ProjContext.Web.CurrentUser;
             IEnumerable<EnterpriseResource> resources =
                 ProjContext.LoadQuery(ProjContext.EnterpriseResources.Where(r => r.Name == user.Title).IncludeWithDefaultProperties(r => r.User));


### PR DESCRIPTION
UserPrincipal.Current.DisplayName causes a error when working on WIndows 10 AzureAD Joined machines - and it also refers to the locally logged on account which has little value when using Project Online and supplying alternate credentials.