### PR TITLE
Fixing javascript modules links in readme.md

### DIFF
--- a/O365-Project-Online-JavaScript-Samples/README.md
+++ b/O365-Project-Online-JavaScript-Samples/README.md
@@ -8,9 +8,9 @@ To use this Project Online JSOM code sample, you need the following:
 * The SharePoint and Project JavaScript libraries for CSOM
 
 ###Modules
-* [CreateProject](/createproject.js)
-* [UpdateProject](/updateproject.js)
-* [UpdateProjectCustomFields](/updateprojectcustomfieldvalues.js)
+* [CreateProject](/O365-Project-Online-JavaScript-Samples/createproject.js)
+* [UpdateProject](/O365-Project-Online-JavaScript-Samples/updateproject.js)
+* [UpdateProjectCustomFields](/O365-Project-Online-JavaScript-Samples/updateprojectcustomfieldvalues.js)
 
 ##How the sample affects your tenant data
 This sample runs JSOM commands that create, read, update, or delete data. When running commands that delete or edit data, the sample creates fake entities. The fake entities are created or edited so that your actual tenant data is unaffected. The sample will leave behind fake entities on your tenant.


### PR DESCRIPTION
Fixed module links in js samples readme.md.  Links were missing `/O365-Project-Online-JavaScript-Samples` path.